### PR TITLE
Bug fix in physical to virtual memory address conversion.

### DIFF
--- a/src/kernel/arch/x86_64/memory.c
+++ b/src/kernel/arch/x86_64/memory.c
@@ -1459,7 +1459,7 @@ arch_vmem_addr_v2p(struct vmem_space *space, void *vaddr)
         /* 2-MiB paging */
         /* Get the offset */
         off = ((reg_t)vaddr) & 0x1fffffULL;
-        return (void *)(VMEM_PDPG(avmem->vls[idxpd][idxp]) + off);
+        return (void *)(VMEM_PDPG(VMEM_PD(avmem->array, idxpd)[idxp]) + off);
     } else {
         /* 4-KiB paging */
         pt = VMEM_PT(avmem->vls[idxpd][idxp]);


### PR DESCRIPTION
Fix the bug of the invalid memory conversion from a virtual address to a physical address.
